### PR TITLE
feat: add contact preference dropdown to unified forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The contact forms use a unified `ContactForm` component with the following field
 - Email address (required)
 - Phone number (required)
 - Home or commercial address (required)
+- Contact preference: Call, Email, or Text (required)
 - Additional information (optional)
 
 The forms currently log data to the console. To integrate with a backend:

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -10,6 +10,7 @@ interface FormData {
   email: string
   phone: string
   address: string
+  contactPreference: string
   additionalInfo: string
 }
 
@@ -19,12 +20,13 @@ const ContactForm = ({ variant = 'homepage', onSubmit }: ContactFormProps) => {
     email: '',
     phone: '',
     address: '',
+    contactPreference: '',
     additionalInfo: ''
   })
 
   const [isSubmitted, setIsSubmitted] = useState(false)
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target
     setFormData(prev => ({
       ...prev,
@@ -54,6 +56,7 @@ const ContactForm = ({ variant = 'homepage', onSubmit }: ContactFormProps) => {
         email: '',
         phone: '',
         address: '',
+        contactPreference: '',
         additionalInfo: ''
       })
     }, 3000)
@@ -146,6 +149,25 @@ const ContactForm = ({ variant = 'homepage', onSubmit }: ContactFormProps) => {
               placeholder="123 Main St, City, State 12345"
             />
           </div>
+        </div>
+
+        <div className="mb-10">
+          <label htmlFor="contactPreference" className="block text-lg font-semibold text-sage-800 mb-4">
+            How would you like to be contacted? *
+          </label>
+          <select
+            id="contactPreference"
+            name="contactPreference"
+            value={formData.contactPreference}
+            onChange={handleInputChange}
+            required
+            className="w-full px-6 py-5 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 text-lg hover:border-sage-300"
+          >
+            <option value="">Select contact method</option>
+            <option value="call">Call</option>
+            <option value="email">Email</option>
+            <option value="text">Text</option>
+          </select>
         </div>
 
         <div className="mb-12">
@@ -243,6 +265,25 @@ const ContactForm = ({ variant = 'homepage', onSubmit }: ContactFormProps) => {
             placeholder="123 Main St, City, State 12345"
           />
         </div>
+      </div>
+
+      <div>
+        <label htmlFor="contactPreference" className="block text-sm font-medium text-gray-700 mb-2">
+          How would you like to be contacted? *
+        </label>
+        <select
+          id="contactPreference"
+          name="contactPreference"
+          value={formData.contactPreference}
+          onChange={handleInputChange}
+          required
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+        >
+          <option value="">Select contact method</option>
+          <option value="call">Call</option>
+          <option value="email">Email</option>
+          <option value="text">Text</option>
+        </select>
       </div>
 
       <div>

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -10,6 +10,7 @@ describe('ContactForm', () => {
     expect(screen.getByLabelText(/email address/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/phone number/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/home or commercial address/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/how would you like to be contacted/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/additional information/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /begin my journey/i })).toBeInTheDocument()
   })
@@ -21,6 +22,7 @@ describe('ContactForm', () => {
     expect(screen.getByLabelText(/email address/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/phone number/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/home or commercial address/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/how would you like to be contacted/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/additional information/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /request my free estimate/i })).toBeInTheDocument()
   })
@@ -36,6 +38,7 @@ describe('ContactForm', () => {
     expect(screen.getByLabelText(/email address/i)).toBeRequired()
     expect(screen.getByLabelText(/phone number/i)).toBeRequired()
     expect(screen.getByLabelText(/home or commercial address/i)).toBeRequired()
+    expect(screen.getByLabelText(/how would you like to be contacted/i)).toBeRequired()
   })
 
   it('calls onSubmit with form data when submitted', async () => {
@@ -47,6 +50,7 @@ describe('ContactForm', () => {
     fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'john@example.com' } })
     fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '(555) 123-4567' } })
     fireEvent.change(screen.getByLabelText(/home or commercial address/i), { target: { value: '123 Main St, City, State 12345' } })
+    fireEvent.change(screen.getByLabelText(/how would you like to be contacted/i), { target: { value: 'email' } })
     fireEvent.change(screen.getByLabelText(/additional information/i), { target: { value: 'Test message' } })
     
     // Submit the form
@@ -58,6 +62,7 @@ describe('ContactForm', () => {
         email: 'john@example.com',
         phone: '(555) 123-4567',
         address: '123 Main St, City, State 12345',
+        contactPreference: 'email',
         additionalInfo: 'Test message'
       })
     })
@@ -71,6 +76,7 @@ describe('ContactForm', () => {
     fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'john@example.com' } })
     fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '(555) 123-4567' } })
     fireEvent.change(screen.getByLabelText(/home or commercial address/i), { target: { value: '123 Main St' } })
+    fireEvent.change(screen.getByLabelText(/how would you like to be contacted/i), { target: { value: 'call' } })
     
     // Submit the form
     fireEvent.click(screen.getByRole('button', { name: /request my free estimate/i }))
@@ -90,6 +96,7 @@ describe('ContactForm', () => {
     fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'john@example.com' } })
     fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '(555) 123-4567' } })
     fireEvent.change(screen.getByLabelText(/home or commercial address/i), { target: { value: '123 Main St' } })
+    fireEvent.change(screen.getByLabelText(/how would you like to be contacted/i), { target: { value: 'text' } })
 
     fireEvent.click(screen.getByRole('button', { name: /begin my journey/i }))
 
@@ -98,6 +105,7 @@ describe('ContactForm', () => {
       email: 'john@example.com',
       phone: '(555) 123-4567',
       address: '123 Main St',
+      contactPreference: 'text',
       additionalInfo: ''
     })
   })


### PR DESCRIPTION
- Add required 'How would you like to be contacted?' dropdown
- Options: Call, Email, Text
- Position above Additional Information field
- Update both homepage and contact page variants
- Update all tests to include new field validation
- Update documentation to reflect new field

All tests passing (6/6) and build successful.