### PR TITLE
feat: replace house emoji with image in About page Family Business se…

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -75,7 +75,13 @@ const AboutPage = () => {
               </div>
             </div>
             <div className="bg-sage-100 rounded-2xl p-8 text-center">
-              <div className="text-6xl mb-4">🏡</div>
+              <div className="w-16 h-16 mx-auto mb-4">
+                <img
+                  src="/images/icons/house.svg"
+                  alt="Family Business"
+                  className="w-full h-full object-contain"
+                />
+              </div>
               <h3 className="text-2xl font-bold text-sage-900 mb-4">Family Business</h3>
               <p className="text-sage-700">
                 We treat every garden like our own and every home like family.


### PR DESCRIPTION
…ction

- Replace 🏡 emoji with proper image element
- Use /images/icons/house.svg as image source
- Maintain same visual size (64px) and center alignment
- Add proper alt text for accessibility
- Ready for custom house image upload

The Family Business section now uses a professional image instead of emoji.