### PR TITLE
Remove bonding references while keeping insurance coverage

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,7 +1,7 @@
 const AboutPage = () => {
   const reasons = [
     'Family-owned and operated',
-    'Fully insured and bonded for your peace of mind',
+    'Fully insured for your peace of mind',
     'Eco-conscious methods that protect your lawn ecosystem',
     'Flexible scheduling to fit your busy lifestyle',
     'Transparent pricing with no hidden fees or surprises',

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -303,7 +303,7 @@ const ContactPage = () => {
                   <svg className="w-8 h-8 mb-4 text-primary-200" fill="currentColor" viewBox="0 0 20 20">
                     <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                   </svg>
-                  <span className="text-lg font-semibold">Fully Insured & Bonded</span>
+                  <span className="text-lg font-semibold">Fully Insured</span>
                 </div>
                 <div className="flex flex-col items-center">
                   <svg className="w-8 h-8 mb-4 text-primary-200" fill="currentColor" viewBox="0 0 20 20">

--- a/src/pages/__tests__/ContactPage.test.tsx
+++ b/src/pages/__tests__/ContactPage.test.tsx
@@ -173,7 +173,7 @@ describe('ContactPage', () => {
     
     expect(screen.getByText('Why Choose Field & Foyer?')).toBeInTheDocument()
     expect(screen.getByText('100% Satisfaction Guarantee')).toBeInTheDocument()
-    expect(screen.getByText('Fully Insured & Bonded')).toBeInTheDocument()
+    expect(screen.getByText('Fully Insured')).toBeInTheDocument()
     expect(screen.getByText('Eco-Friendly Methods')).toBeInTheDocument()
     expect(screen.getByText('Local Family Business')).toBeInTheDocument()
   })

--- a/src/pages/services/PetWasteRemovalPage.tsx
+++ b/src/pages/services/PetWasteRemovalPage.tsx
@@ -169,7 +169,7 @@ const PetWasteRemovalPage = () => {
                     <li>• Flexible scheduling around residents</li>
                     <li>• Professional, uniformed service teams</li>
                     <li>• Detailed service reporting</li>
-                    <li>• Liability insurance and bonding</li>
+                    <li>• Liability insurance</li>
                     <li>• Emergency and on-call services</li>
                   </ul>
                 </div>


### PR DESCRIPTION
## Summary

Removes all references to "bonding" from the website while preserving "fully insured" messaging, as the business is fully insured but not bonded.

## Changes Made

### Files Updated:
- **AboutPage.tsx**: Changed "Fully insured and bonded for your peace of mind" → "Fully insured for your peace of mind"
- **ContactPage.tsx**: Changed "Fully Insured & Bonded" → "Fully Insured"
- **PetWasteRemovalPage.tsx**: Changed "Liability insurance and bonding" → "Liability insurance"
- **ContactPage.test.tsx**: Updated test expectations to match new text content

## Verification

✅ Comprehensive search conducted across all file types (`.tsx`, `.ts`, `.js`, `.jsx`, `.md`, `.json`)
✅ Confirmed no "bond", "bonded", or "bonding" references remain in codebase
✅ All insurance references preserved
✅ Test files updated to maintain consistency

## Impact

- Ensures accurate representation of business insurance status
- Maintains professional messaging while removing inaccurate claims
- No functional changes to website behavior
- Tests updated to reflect new content

This change aligns the website content with the actual business insurance coverage.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author