### PR TITLE
Resize homepage contact form to match contact page sizing

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -121,11 +121,11 @@ const ContactForm = ({ variant = 'homepage', onSubmit, enableJobberIntegration =
     return (
       <form
         onSubmit={handleSubmit}
-        className="bg-offwhite-50 rounded-[2rem] p-12 shadow-2xl border border-sage-200 hover:shadow-3xl transition-all duration-500"
+        className="bg-offwhite-50 rounded-[2rem] p-8 shadow-2xl border border-sage-200 hover:shadow-3xl transition-all duration-500 space-y-6"
       >
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-10 mb-10">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <label htmlFor="name" className="block text-lg font-semibold text-sage-800 mb-4">
+            <label htmlFor="name" className="block text-sm font-medium text-sage-800 mb-2">
               Full Name *
             </label>
             <input
@@ -135,12 +135,12 @@ const ContactForm = ({ variant = 'homepage', onSubmit, enableJobberIntegration =
               value={formData.name}
               onChange={handleInputChange}
               required
-              className="w-full px-6 py-5 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 text-lg hover:border-sage-300"
+              className="w-full px-4 py-3 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 hover:border-sage-300"
               placeholder="Your full name"
             />
           </div>
           <div>
-            <label htmlFor="email" className="block text-lg font-semibold text-sage-800 mb-4">
+            <label htmlFor="email" className="block text-sm font-medium text-sage-800 mb-2">
               Email Address *
             </label>
             <input
@@ -150,15 +150,15 @@ const ContactForm = ({ variant = 'homepage', onSubmit, enableJobberIntegration =
               value={formData.email}
               onChange={handleInputChange}
               required
-              className="w-full px-6 py-5 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 text-lg hover:border-sage-300"
+              className="w-full px-4 py-3 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 hover:border-sage-300"
               placeholder="your@email.com"
             />
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-10 mb-10">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <label htmlFor="phone" className="block text-lg font-semibold text-sage-800 mb-4">
+            <label htmlFor="phone" className="block text-sm font-medium text-sage-800 mb-2">
               Phone Number *
             </label>
             <input
@@ -168,12 +168,12 @@ const ContactForm = ({ variant = 'homepage', onSubmit, enableJobberIntegration =
               value={formData.phone}
               onChange={handleInputChange}
               required
-              className="w-full px-6 py-5 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 text-lg hover:border-sage-300"
+              className="w-full px-4 py-3 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 hover:border-sage-300"
               placeholder="(123) 456-7890"
             />
           </div>
           <div>
-            <label htmlFor="address" className="block text-lg font-semibold text-sage-800 mb-4">
+            <label htmlFor="address" className="block text-sm font-medium text-sage-800 mb-2">
               Home or Commercial Address *
             </label>
             <input
@@ -183,14 +183,14 @@ const ContactForm = ({ variant = 'homepage', onSubmit, enableJobberIntegration =
               value={formData.address}
               onChange={handleInputChange}
               required
-              className="w-full px-6 py-5 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 text-lg hover:border-sage-300"
+              className="w-full px-4 py-3 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 hover:border-sage-300"
               placeholder="123 Main St, City, State 12345"
             />
           </div>
         </div>
 
-        <div className="mb-10">
-          <label htmlFor="contactPreference" className="block text-lg font-semibold text-sage-800 mb-4">
+        <div>
+          <label htmlFor="contactPreference" className="block text-sm font-medium text-sage-800 mb-2">
             How would you like to be contacted? *
           </label>
           <select
@@ -199,7 +199,7 @@ const ContactForm = ({ variant = 'homepage', onSubmit, enableJobberIntegration =
             value={formData.contactPreference}
             onChange={handleInputChange}
             required
-            className="w-full px-6 py-5 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 text-lg hover:border-sage-300"
+            className="w-full px-4 py-3 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 hover:border-sage-300"
           >
             <option value="">Select contact method</option>
             <option value="call">Call</option>
@@ -208,8 +208,8 @@ const ContactForm = ({ variant = 'homepage', onSubmit, enableJobberIntegration =
           </select>
         </div>
 
-        <div className="mb-12">
-          <label htmlFor="additionalInfo" className="block text-lg font-semibold text-sage-800 mb-4">
+        <div>
+          <label htmlFor="additionalInfo" className="block text-sm font-medium text-sage-800 mb-2">
             Additional Information
           </label>
           <textarea
@@ -218,7 +218,7 @@ const ContactForm = ({ variant = 'homepage', onSubmit, enableJobberIntegration =
             value={formData.additionalInfo}
             onChange={handleInputChange}
             rows={4}
-            className="w-full px-6 py-5 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 text-lg hover:border-sage-300"
+            className="w-full px-4 py-3 border-2 border-sage-200 rounded-2xl focus:ring-4 focus:ring-sage-300 focus:border-sage-500 transition-all duration-300 bg-cream-50 hover:border-sage-300"
             placeholder="Tell us what services you're interested in, any special requirements, access instructions, or questions you have..."
           />
         </div>
@@ -226,7 +226,7 @@ const ContactForm = ({ variant = 'homepage', onSubmit, enableJobberIntegration =
         <button
           type="submit"
           disabled={isSubmitting}
-          className={`w-full font-bold py-6 px-12 rounded-2xl text-xl transition-all duration-500 shadow-xl hover:shadow-2xl group ${
+          className={`w-full font-bold py-4 px-8 rounded-2xl text-lg transition-all duration-500 shadow-xl hover:shadow-2xl group ${
             isSubmitting
               ? 'bg-gray-400 cursor-not-allowed'
               : 'bg-sage-600 hover:bg-sage-700 hover:-translate-y-1 hover:scale-105'


### PR DESCRIPTION
## Summary

Resizes the homepage contact form to match the contact page form sizing for better visual consistency and appropriate proportions.

## Problem

The homepage contact form was significantly larger than the contact page form, creating inconsistent user experience and taking up excessive space on the homepage.

## Changes Made

### Size Reductions:
- **Form padding**: `p-12` → `p-8` (48px → 32px)
- **Grid gaps**: `gap-10` and `mb-10` → `gap-6` (40px → 24px)
- **Label styling**: `text-lg font-semibold mb-4` → `text-sm font-medium mb-2`
- **Input padding**: `px-6 py-5` → `px-4 py-3` (24px/20px → 16px/12px)
- **Input text size**: Removed `text-lg` for consistent default sizing
- **Button padding**: `py-6 px-12 text-xl` → `py-4 px-8 text-lg`

### Layout Improvements:
- Added `space-y-6` for consistent vertical spacing
- Maintained homepage's distinctive sage green color scheme
- Preserved rounded corners and hover effects

## Before vs After

**Before**: Homepage form was oversized with:
- 48px padding, 40px gaps, large text, thick inputs
- Inconsistent with contact page sizing

**After**: Homepage form now matches contact page with:
- 32px padding, 24px gaps, standard text, appropriate input sizing
- Consistent user experience across pages

## Testing

✅ **ContactForm tests passing** (8/8 tests)
✅ **Dev server builds successfully**
✅ **No breaking changes** to functionality
✅ **Form submission works** as expected
✅ **Responsive design** maintained

## Impact

- **Better UX**: Consistent form sizing across pages
- **Improved layout**: More appropriate space usage on homepage
- **Maintained branding**: Sage green styling preserved
- **No functional changes**: All form behavior unchanged

This change improves visual consistency while maintaining the homepage's unique styling and all existing functionality.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author