### PR TITLE
Update pricing structure and add minimum charge notice

### DIFF
--- a/src/pages/pricing/PetWasteRemovalPricingPage.tsx
+++ b/src/pages/pricing/PetWasteRemovalPricingPage.tsx
@@ -19,7 +19,7 @@ const PetWasteRemovalPricingPage = () => {
         'Professional service guarantee'
       ],
       pricing: {
-        '1-2 dogs': { standard: 25, large: 40 },
+        '1-2 dogs': { standard: 25, large: 35 },
         '3+ dogs': { standard: 35, large: 50 }
       }
     },
@@ -38,7 +38,7 @@ const PetWasteRemovalPricingPage = () => {
       ],
       pricing: {
         '1-2 dogs': { standard: 35, large: 50 },
-        '3+ dogs': { standard: 50, large: 65 }
+        '3+ dogs': { standard: 50, large: 70 }
       }
     },
     {
@@ -54,8 +54,8 @@ const PetWasteRemovalPricingPage = () => {
         'Satisfaction guarantee'
       ],
       pricing: {
-        '1-2 dogs': { standard: 125, large: 140 },
-        '3+ dogs': { standard: 175, large: 190 }
+        '1-2 dogs': { standard: 125, large: 175 },
+        '3+ dogs': { standard: 175, large: 250 }
       }
     }
   ]

--- a/src/pages/pricing/PetWasteRemovalPricingPage.tsx
+++ b/src/pages/pricing/PetWasteRemovalPricingPage.tsx
@@ -19,8 +19,8 @@ const PetWasteRemovalPricingPage = () => {
         'Professional service guarantee'
       ],
       pricing: {
-        '1-2 dogs': { small: 25, large: 35 },
-        '3+ dogs': { small: 35, large: 50 }
+        '1-2 dogs': { standard: 25, large: 40 },
+        '3+ dogs': { standard: 35, large: 50 }
       }
     },
     {
@@ -37,8 +37,8 @@ const PetWasteRemovalPricingPage = () => {
         'Service updates'
       ],
       pricing: {
-        '1-2 dogs': { small: 35, large: 50 },
-        '3+ dogs': { small: 50, large: 70 }
+        '1-2 dogs': { standard: 35, large: 50 },
+        '3+ dogs': { standard: 50, large: 65 }
       }
     },
     {
@@ -54,8 +54,8 @@ const PetWasteRemovalPricingPage = () => {
         'Satisfaction guarantee'
       ],
       pricing: {
-        '1-2 dogs': { small: 125, large: 175 },
-        '3+ dogs': { small: 175, large: 250 }
+        '1-2 dogs': { standard: 125, large: 140 },
+        '3+ dogs': { standard: 175, large: 190 }
       }
     }
   ]
@@ -117,6 +117,9 @@ const PetWasteRemovalPricingPage = () => {
                     <span className={`text-lg ${plan.popular ? 'text-sage-100' : 'text-sage-600'}`}>
                       /visit
                     </span>
+                    <div className={`text-xs mt-2 ${plan.popular ? 'text-sage-200' : 'text-sage-500'}`}>
+                      $20 minimum charge applies
+                    </div>
                   </div>
                 </div>
 
@@ -156,20 +159,27 @@ const PetWasteRemovalPricingPage = () => {
                 <thead>
                   <tr className="border-b border-sage-200">
                     <th className="text-left py-3 px-4 font-semibold text-sage-800">Number of Dogs</th>
-                    <th className="text-center py-3 px-4 font-semibold text-sage-800">Standard Yard<br/><span className="text-sm font-normal">(1/4 - 3/4 acre)</span></th>
-                    <th className="text-center py-3 px-4 font-semibold text-sage-800">Large Yard<br/><span className="text-sm font-normal">(1+ acre)</span></th>
+                    <th className="text-center py-3 px-4 font-semibold text-sage-800">Standard Yard<br/><span className="text-sm font-normal">(1/4 - 1 acre)</span></th>
+                    <th className="text-center py-3 px-4 font-semibold text-sage-800">Large Yard<br/><span className="text-sm font-normal">(1+ acre)*</span></th>
                   </tr>
                 </thead>
                 <tbody>
                   {Object.entries(pricingPlans.find(p => p.id === selectedPlan)?.pricing || {}).map(([dogs, prices]) => (
                     <tr key={dogs} className="border-b border-sage-100">
                       <td className="py-3 px-4 font-medium text-sage-800">{dogs}</td>
-                      <td className="text-center py-3 px-4 text-sage-700">${prices.small}</td>
+                      <td className="text-center py-3 px-4 text-sage-700">${prices.standard}</td>
                       <td className="text-center py-3 px-4 text-sage-700">${prices.large}</td>
                     </tr>
                   ))}
                 </tbody>
               </table>
+            </div>
+
+            <div className="mt-6 p-4 bg-sage-50 rounded-lg border border-sage-200">
+              <p className="text-sm text-sage-700">
+                <span className="font-semibold">*Large Yard Pricing:</span> Base price shown is for 1+ acre properties.
+                Additional $15 charge applies for each additional 1/4 acre beyond the first acre.
+              </p>
             </div>
           </div>
         </div>

--- a/src/pages/pricing/__tests__/PetWasteRemovalPricingPage.test.tsx
+++ b/src/pages/pricing/__tests__/PetWasteRemovalPricingPage.test.tsx
@@ -101,6 +101,32 @@ describe('PetWasteRemovalPricingPage', () => {
     // Check that pricing table headers are present
     expect(screen.getByText('Number of Dogs')).toBeInTheDocument()
     expect(screen.getByText(/Standard Yard/)).toBeInTheDocument()
-    expect(screen.getByText(/Large Yard/)).toBeInTheDocument()
+    // Use getAllByText to handle multiple "Large Yard" occurrences
+    const largeYardElements = screen.getAllByText(/Large Yard/)
+    expect(largeYardElements.length).toBeGreaterThan(0)
+  })
+
+  it('displays $20 minimum charge on all pricing cards', () => {
+    render(<PetWasteRemovalPricingPage />)
+
+    // Check that all three cards show the $20 minimum charge
+    const minimumChargeTexts = screen.getAllByText('$20 minimum charge applies')
+    expect(minimumChargeTexts).toHaveLength(3)
+  })
+
+  it('shows updated yard size ranges in table headers', () => {
+    render(<PetWasteRemovalPricingPage />)
+
+    // Check for updated yard size ranges
+    expect(screen.getByText('(1/4 - 1 acre)')).toBeInTheDocument()
+    expect(screen.getByText('(1+ acre)*')).toBeInTheDocument()
+  })
+
+  it('displays large yard pricing explanation', () => {
+    render(<PetWasteRemovalPricingPage />)
+
+    // Check for the large yard pricing explanation
+    expect(screen.getByText(/Large Yard Pricing:/)).toBeInTheDocument()
+    expect(screen.getByText(/Additional \$15 charge applies for each additional 1\/4 acre/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

This PR updates the pet waste removal pricing page to implement the new pricing structure and add required minimum charge notices **WITHOUT changing any existing prices**.

## Changes Made

### ✅ Pricing Card Updates
- Added **$20 minimum charge** fine print to all three service cards (Weekly, Bi-weekly, One-time)
- Styled with appropriate text size and color contrast

### ✅ Yard Size Structure Update
**Before:**
- Standard Yard (1/4 - 3/4 acre)
- Large Yard (1+ acre)

**After:**
- Standard Yard (1/4 - 1 acre) - Base pricing
- Large Yard (1+ acre)* - With $15 upcharge per additional 1/4 acre

### ✅ **IMPORTANT: All Original Prices Maintained**

**Weekly Service:** (ORIGINAL PRICES KEPT)
- 1-2 dogs: Standard $25, Large $35
- 3+ dogs: Standard $35, Large $50

**Bi-weekly Service:** (ORIGINAL PRICES KEPT)
- 1-2 dogs: Standard $35, Large $50
- 3+ dogs: Standard $50, Large $70

**One-time Cleanup:** (ORIGINAL PRICES KEPT)
- 1-2 dogs: Standard $125, Large $175
- 3+ dogs: Standard $175, Large $250

### ✅ Added Pricing Explanation
Added clear explanation box below pricing table:
> "*Large Yard Pricing: Base price shown is for 1+ acre properties. Additional $15 charge applies for each additional 1/4 acre beyond the first acre."

## Fix Applied

⚠️ **Initial commit incorrectly changed some pricing values. This has been FIXED in commit 327c57c:**
- Reverted ALL pricing to original values
- Only structural changes remain (yard size labels and minimum charge notice)
- No pricing numbers were changed from the original

## Testing

- ✅ All pricing page tests passing (14/14)
- ✅ Added new tests for $20 minimum charge display
- ✅ Added tests for updated yard size ranges
- ✅ Added tests for large yard pricing explanation
- ✅ Verified all original prices are maintained

## Files Changed

- `src/pages/pricing/PetWasteRemovalPricingPage.tsx` - Main pricing component
- `src/pages/pricing/__tests__/PetWasteRemovalPricingPage.test.tsx` - Updated tests

## What This PR Does

✅ **ONLY the requested changes:**
1. Adds $20 minimum fine print on each card
2. Updates yard size labels (1/4-1 acre standard, 1+ acre with upcharge explanation)
3. Adds clear pricing explanation for customers

❌ **Does NOT change any existing prices**

## Ready for Review

This PR now contains ONLY the structural changes requested, with all original pricing values preserved exactly as they were.