### PR TITLE
Fix TypeScript errors in HomePage partnerships test

### DIFF
--- a/src/test/HomePage.partnerships.test.tsx
+++ b/src/test/HomePage.partnerships.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
-import { vi } from 'vitest'
+import { vi, describe, test, expect } from 'vitest'
 import HomePage from '../pages/HomePage'
 
 // Mock the useJobberSubmission hook

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -21,6 +22,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/__tests__/**"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/__tests__/**/*",
+    "src/test/**/*"
+  ],
+  "exclude": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,5 +13,8 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    typecheck: {
+      tsconfig: './tsconfig.test.json'
+    }
   },
 })


### PR DESCRIPTION
## Summary

Fixed TypeScript errors in `src/test/HomePage.partnerships.test.tsx` that were preventing proper type checking and IDE support.

## Changes Made

### 1. Fixed missing test imports
- Added `vi, describe, test, expect` imports from 'vitest' to resolve undefined globals

### 2. Updated TypeScript configuration
- Added `"types": ["vitest/globals", "@testing-library/jest-dom"]` to main `tsconfig.json`
- Removed test file exclusions from main tsconfig to enable proper type checking
- Created `tsconfig.test.json` for test-specific configuration
- Updated `vite.config.ts` to use test-specific TypeScript config

## Issues Resolved

- ✅ `Cannot find name 'expect'.ts(2304)`
- ✅ `Cannot find name 'test'. Do you need to install type definitions for a test runner?`
- ✅ `Cannot find name 'describe'. Do you need to install type definitions for a test runner?`
- ✅ `'React' refers to a UMD global, but the current file is a module`

## Testing

- All 4 partnership tests pass successfully
- TypeScript compilation passes without errors
- No breaking changes to existing functionality

## Files Changed

- `src/test/HomePage.partnerships.test.tsx` - Added missing vitest imports
- `tsconfig.json` - Added vitest types and removed test exclusions
- `tsconfig.test.json` - New test-specific TypeScript configuration
- `vite.config.ts` - Added typecheck configuration for tests

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author